### PR TITLE
Minor fixes to gitignore and main-index.css

### DIFF
--- a/app/templates/_gitignore
+++ b/app/templates/_gitignore
@@ -1,3 +1,4 @@
 dist/src/*.js
 dist/build/*.js
 dist/build/**
+node_modules

--- a/app/templates/dist/dev/css/main-index.css
+++ b/app/templates/dist/dev/css/main-index.css
@@ -6,7 +6,6 @@ html, body
     height     : 100%;
     min-width  : 360px !important;
     margin     : 0 auto;
-    text-align : left;
     background-color : #ffffff;
     font-family      : 'roboto_regular';
 }

--- a/app/templates/dist/dev/css/main-index.css
+++ b/app/templates/dist/dev/css/main-index.css
@@ -6,7 +6,7 @@ html, body
     height     : 100%;
     min-width  : 360px !important;
     margin     : 0 auto;
-    text-align : center;
+    text-align : left;
     background-color : #ffffff;
     font-family      : 'roboto_regular';
 }


### PR DESCRIPTION
Just some minor changes. Body shouldn't have text be centered by the CSS file. Leads to confusion since changing the JSS doesn't fix the issue. Also gitignored node_modules cause otherwise it can lead to gigantic repos, even if the folder is later deleted from the repo