### PR TITLE
simplified file and lib paths

### DIFF
--- a/app/templates/src/js/modules/RoutingApp.js
+++ b/app/templates/src/js/modules/RoutingApp.js
@@ -1,9 +1,9 @@
-import Provider from 'react-redux/lib/components/Provider';
+import { Provider } from 'react-redux';
 import React, { Component } from 'react';
-import Route from 'react-router-dom/Route';
+import { Route } from 'react-router-dom';
 import appHistory from 'tools/appHistory';
 import MainApp from './core/components/MainApp';
-import ConnectedRouter from 'react-router-redux/ConnectedRouter';
+import { ConnectedRouter } from 'react-router-redux';
 import store from '../store';
 
 

--- a/app/templates/src/js/modules/core/components/MainApp.js
+++ b/app/templates/src/js/modules/core/components/MainApp.js
@@ -1,9 +1,9 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import injectSheet from 'react-jss'
-import connect from 'react-redux/lib/connect/connect'
+import { connect } from 'react-redux'
 
-import { refreshWindowDimensions } from './../coreActions'
+import { refreshWindowDimensions } from '../coreActions'
 
 const styles = {
     appWrapper : {

--- a/app/templates/src/js/modules/core/coreReducer.js
+++ b/app/templates/src/js/modules/core/coreReducer.js
@@ -1,4 +1,4 @@
-import { REFRESH_WINDOW_DIMENSIONS } from "./coreActions";
+import { REFRESH_WINDOW_DIMENSIONS } from './coreActions';
 
 // getWindowWidth & getWindowHeight was
 // adapted from http://stackoverflow.com/a/8876069/1291659

--- a/app/templates/src/js/modules/core/index.js
+++ b/app/templates/src/js/modules/core/index.js
@@ -1,4 +1,4 @@
-import reducer   from '../core/coreReducer'
-import actions   from '../core/coreActions'
+import reducer   from './coreReducer'
+import actions   from './coreActions'
 
 export default { reducer, actions }

--- a/app/templates/src/js/store.js
+++ b/app/templates/src/js/store.js
@@ -1,4 +1,4 @@
-import { applyMiddleware, createStore } from 'redux/lib/applyMiddleware'
+import { applyMiddleware, createStore } from 'redux'
 import thunk  from 'redux-thunk'
 import promise from 'redux-promise-middleware'
 import reducer from './reducers'

--- a/app/templates/src/js/store.js
+++ b/app/templates/src/js/store.js
@@ -1,5 +1,4 @@
-import applyMiddleware from 'redux/lib/applyMiddleware'
-import createStore from 'redux/lib/createStore'
+import { applyMiddleware, createStore } from 'redux/lib/applyMiddleware'
 import thunk  from 'redux-thunk'
 import promise from 'redux-promise-middleware'
 import reducer from './reducers'


### PR DESCRIPTION
This PR simplifies import paths. I've already validated the exports from `node_modules/module-names` and tested the simplified imports on a demo app.
